### PR TITLE
Fix ALCPlugFix install/uninstall logic

### DIFF
--- a/ALCPlugFix/one-key-alcplugfix.sh
+++ b/ALCPlugFix/one-key-alcplugfix.sh
@@ -99,13 +99,17 @@ function uninstall() {
     sudo rm -rf /usr/local/bin/ALCPlugFix
     sudo rm -rf /usr/local/bin/hda-verb
     echo "Uninstall complete"
-    exit 0
+    echo 
+    if [[ $1 = "cleanup" ]]; then 
+    return
+    else exit 0 
+    fi
 }
 
 # Install function
 function install() {
     download
-    uninstall
+    uninstall "cleanup"
     copy
     fixpermission
     loadservice

--- a/ALCPlugFix/one-key-alcplugfix_cn.sh
+++ b/ALCPlugFix/one-key-alcplugfix_cn.sh
@@ -99,13 +99,17 @@ function uninstall() {
     sudo rm -rf /usr/local/bin/ALCPlugFix
     sudo rm -rf /usr/local/bin/hda-verb
     echo "卸载完成"
-    exit 0
+    echo 
+    if [[ $1 = "cleanup" ]]; then 
+    return
+    else exit 0 
+    fi
 }
 
 # 安装程序
 function install(){
     download
-    uninstall
+    uninstall "cleanup"
     copy
     fixpermission
     loadservice


### PR DESCRIPTION
This fix updates the install/uninstall logic to use a cleanup parameter when the uninstall method is being used for cleanup. It avoids the script from exiting earlier than expected. 